### PR TITLE
fix(elasticsearch): Send authorization headers also for GET methods

### DIFF
--- a/gravitee-repository-elasticsearch-http/src/main/java/io/gravitee/repository/elasticsearch/ElasticsearchComponent.java
+++ b/gravitee-repository-elasticsearch-http/src/main/java/io/gravitee/repository/elasticsearch/ElasticsearchComponent.java
@@ -145,6 +145,7 @@ public class ElasticsearchComponent {
 	private int getMajorVersion() throws ExecutionException, InterruptedException, IOException, TechnicalException {
 		Observable<VertxHttpResponse> get = Observable.unsafeCreate(subscriber -> {
 			HttpClientRequest req = httpClient.get("/");
+			addCommonHeaders(req);
 			Observable<VertxHttpResponse> responseObservable = req
 					.exceptionHandler(subscriber::onError)
 					.toObservable()
@@ -203,6 +204,7 @@ public class ElasticsearchComponent {
 		try {
 			Observable<VertxHttpResponse> get = Observable.unsafeCreate(subscriber -> {
 				HttpClientRequest req = httpClient.get(URL_STATE_CLUSTER);
+				addCommonHeaders(req);
 				Observable<VertxHttpResponse> responseObservable = req
 						.exceptionHandler(subscriber::onError)
 						.toObservable()


### PR DESCRIPTION
Closes gravitee-io/issues#898