### PR TITLE
fix(monitoring): Switch Double to Number in loadAverage map for Monit…

### DIFF
--- a/gravitee-repository-elasticsearch-v2x/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticMonitoringRepository.java
+++ b/gravitee-repository-elasticsearch-v2x/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticMonitoringRepository.java
@@ -87,7 +87,7 @@ public class ElasticMonitoringRepository extends AbstractElasticRepository imple
 
         final Map<String, Object> cpu = (Map<String, Object>) os.get("cpu");
         monitoringResponse.setOsCPUPercent((Integer) cpu.get("percent"));
-        monitoringResponse.setOsCPULoadAverage((Map<String, Double>) cpu.get("load_average"));
+        monitoringResponse.setOsCPULoadAverage((Map<String, ? super Number>) cpu.get("load_average"));
 
         final Map<String, Object> osMem = (Map<String, Object>) os.get("mem");
         monitoringResponse.setOsMemUsedInBytes(getLongValue(osMem.get("used_in_bytes")));

--- a/gravitee-repository-elasticsearch-v5x/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticMonitoringRepository.java
+++ b/gravitee-repository-elasticsearch-v5x/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticMonitoringRepository.java
@@ -87,7 +87,7 @@ public class ElasticMonitoringRepository extends AbstractElasticRepository imple
 
         final Map<String, Object> cpu = (Map<String, Object>) os.get("cpu");
         monitoringResponse.setOsCPUPercent((Integer) cpu.get("percent"));
-        monitoringResponse.setOsCPULoadAverage((Map<String, Double>) cpu.get("load_average"));
+        monitoringResponse.setOsCPULoadAverage((Map<String, ? super Number  >) cpu.get("load_average"));
 
         final Map<String, Object> osMem = (Map<String, Object>) os.get("mem");
         monitoringResponse.setOsMemUsedInBytes(getLongValue(osMem.get("used_in_bytes")));

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<gravitee-repository.version>1.11.0</gravitee-repository.version>
+		<gravitee-repository.version>1.12.0-SNAPSHOT</gravitee-repository.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
…oringCPU to avoid ClassCast issue for int value. Adapted relative dependencies on api-service and other modules.

Closes gravitee-io/issues#925